### PR TITLE
カラム名の修正，SSHKeyを発行してモデルに保存するように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'whenever', :require => false
 
 # other data
 gem 'sshkey'
+gem 'annotate'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    annotate (2.6.10)
+      activerecord (>= 3.2, <= 4.3)
+      rake (~> 10.4)
     ansi (1.5.0)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.10)
@@ -220,6 +223,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   better_errors
   binding_of_caller
   capistrano (~> 3.2.1)
@@ -257,3 +261,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   whenever
+
+BUNDLED WITH
+   1.10.5

--- a/app/controllers/deploy_keys_controller.rb
+++ b/app/controllers/deploy_keys_controller.rb
@@ -22,7 +22,7 @@ class DeployKeysController < ApplicationController
 
   # POST /deploy_keys
   def create
-    @deploy_key = DeployKey.unscoped.where(deploy_key_params).first_or_create
+    @deploy_key = DeployKey.unscoped.where(deploy_key_params).first_or_create.insert_keys
 
     if @deploy_key
       flash[:notice] = 'DeployKey was successfully created.'

--- a/app/models/configuration_parameter.rb
+++ b/app/models/configuration_parameter.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 class ConfigurationParameter < ActiveRecord::Base
   validates :name, :presence => true
   validates :prompt_on_deploy, :inclusion => {:in => 0..1}

--- a/app/models/deploy_key.rb
+++ b/app/models/deploy_key.rb
@@ -1,2 +1,21 @@
+# == Schema Information
+#
+# Table name: deploy_keys
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  passphrase  :string(255)
+#  private_key :text
+#  public_key  :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 class DeployKey < ActiveRecord::Base
+  def insert_keys
+    k = SSHKey.generate
+    self.public_key = k.ssh_public_key
+    self.private_key = k.private_key
+    save
+  end
 end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: deployments
+#
+#  id                :integer          not null, primary key
+#  task              :string(255)
+#  log               :text
+#  stage_id          :integer
+#  created_at        :datetime
+#  updated_at        :datetime
+#  completed_at      :datetime
+#  description       :text
+#  user_id           :integer
+#  excluded_host_ids :string(255)
+#  revision          :string(255)
+#  pid               :integer
+#  status            :string(255)      default("running")
+#
+
 class Deployment < ActiveRecord::Base
   DEPLOY_TASKS    = ['deploy', 'deploy:default', 'deploy:migrations']
   SETUP_TASKS     = ['deploy:setup']

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: hosts
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
+
 class Host < ActiveRecord::Base
   has_many :roles, -> { uniq }, :dependent => :destroy
   has_many :stages, -> { uniq }, :through => :roles # XXX uniq does not seem to work! You get all stages, even doubles

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  template    :string(255)
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 class Project < ActiveRecord::Base
   has_many :stages, -> { order 'name ASC' }, :dependent => :destroy
   has_many :deployments, :through => :stages

--- a/app/models/project_configuration.rb
+++ b/app/models/project_configuration.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 class ProjectConfiguration < ConfigurationParameter
   belongs_to :project
   

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  body        :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 class Recipe < ActiveRecord::Base
   has_and_belongs_to_many :stages
   

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  stage_id   :integer
+#  host_id    :integer
+#  primary    :integer          default(0)
+#  created_at :datetime
+#  updated_at :datetime
+#  no_release :integer          default(0)
+#  ssh_port   :integer
+#  no_symlink :integer          default(0)
+#
+
 class Role < ActiveRecord::Base
   DEFAULT_NAMES = %w(app db web)
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stages
+#
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  project_id              :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  alert_emails            :text
+#  locked_by_deployment_id :integer
+#  locked                  :integer          default(0)
+#
+
 class Stage < ActiveRecord::Base  
   belongs_to :project
   has_and_belongs_to_many :recipes

--- a/app/models/stage_configuration.rb
+++ b/app/models/stage_configuration.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 class StageConfiguration < ConfigurationParameter
   belongs_to :stage
   

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  login                  :string(255)
+#  time_zone              :string(255)      default("UTC")
+#  disabled_at            :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0)
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default(FALSE)
+#
+
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :registerable, :confirmable, :lockable and :timeoutable

--- a/app/views/deploy_keys/_form.slim
+++ b/app/views/deploy_keys/_form.slim
@@ -15,9 +15,9 @@
 
 .deploy-key-input style="display:none"
   .control-group
-    = form.label t("deploy_key.secret_key"), :class => "control-label"
+    = form.label t("deploy_key.private_key"), :class => "control-label"
     .controls
-      = form.text_area :secret_key, :class => "text_field", :style => "width:663px; height: 100px;"
+      = form.text_area :private_key, :class => "text_field", :style => "width:663px; height: 100px;"
 
   .control-group
     = form.label t("deploy_key.public_key"), :class => "control-label"

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Webistrano
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    #config.i18n.default_locale = :ja
+    config.i18n.default_locale = :ja
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/db/migrate/20150520170009_create_deploy_keys.rb
+++ b/db/migrate/20150520170009_create_deploy_keys.rb
@@ -2,9 +2,10 @@ class CreateDeployKeys < ActiveRecord::Migration
   def change
     create_table :deploy_keys do |t|
       t.string :name
-      t.text :secret
-      t.text :public
+      t.string :description
       t.string :passphrase
+      t.text :private_key
+      t.text :public_key
 
       t.timestamps
     end

--- a/db/migrate/20150629024603_add_descriptions_to_deploy_keys.rb
+++ b/db/migrate/20150629024603_add_descriptions_to_deploy_keys.rb
@@ -1,5 +1,0 @@
-class AddDescriptionsToDeployKeys < ActiveRecord::Migration
-  def change
-    add_column :deploy_keys, :description, :text
-  end
-end

--- a/db/migrate/20150629031444_add_ssh_keys_to_deploy_keys.rb
+++ b/db/migrate/20150629031444_add_ssh_keys_to_deploy_keys.rb
@@ -1,6 +1,0 @@
-class AddSshKeysToDeployKeys < ActiveRecord::Migration
-  def change
-    add_column :deploy_keys, :secret_key, :text
-    add_column :deploy_keys, :public_key, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150629031444) do
+ActiveRecord::Schema.define(version: 20150520170009) do
 
   create_table "configuration_parameters", force: true do |t|
     t.string   "name"
@@ -26,14 +26,12 @@ ActiveRecord::Schema.define(version: 20150629031444) do
 
   create_table "deploy_keys", force: true do |t|
     t.string   "name"
-    t.text     "secret"
-    t.text     "public"
+    t.string   "description"
     t.string   "passphrase"
+    t.text     "private_key"
+    t.text     "public_key"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "description"
-    t.text     "secret_key"
-    t.text     "public_key"
   end
 
   create_table "deployments", force: true do |t|
@@ -140,9 +138,9 @@ ActiveRecord::Schema.define(version: 20150629031444) do
     t.boolean  "admin",                  default: false
   end
 
-  add_index "users", ["disabled_at"], name: "index_users_on_disabled_at", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["disabled_at"], name: "index_users_on_disabled_at"
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
   create_table "versions", force: true do |t|
     t.string   "item_type",  null: false
@@ -153,6 +151,6 @@ ActiveRecord::Schema.define(version: 20150629031444) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
+  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
 
 end

--- a/test/factories/deployments.rb
+++ b/test/factories/deployments.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: deployments
+#
+#  id                :integer          not null, primary key
+#  task              :string(255)
+#  log               :text
+#  stage_id          :integer
+#  created_at        :datetime
+#  updated_at        :datetime
+#  completed_at      :datetime
+#  description       :text
+#  user_id           :integer
+#  excluded_host_ids :string(255)
+#  revision          :string(255)
+#  pid               :integer
+#  status            :string(255)      default("running")
+#
+
 FactoryGirl.define do
   factory :deployment do
     stage { |a| a.association(:stage) }

--- a/test/factories/hosts.rb
+++ b/test/factories/hosts.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: hosts
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
+
 FactoryGirl.define do
   factory :host do
     sequence(:name) { |n| "%04d.example.com" % n }

--- a/test/factories/projects.rb
+++ b/test/factories/projects.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  template    :string(255)
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 FactoryGirl.define do
   factory :project do
     sequence(:name) { |n| "Project %04d" % n }

--- a/test/factories/recipes.rb
+++ b/test/factories/recipes.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  body        :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 FactoryGirl.define do
   factory :recipe do
     sequence(:name) { |n| "Recipe %04d" % n }

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  stage_id   :integer
+#  host_id    :integer
+#  primary    :integer          default(0)
+#  created_at :datetime
+#  updated_at :datetime
+#  no_release :integer          default(0)
+#  ssh_port   :integer
+#  no_symlink :integer          default(0)
+#
+
 FactoryGirl.define do
   factory :role do
     sequence(:name) { |n| "Role %04d" % n }

--- a/test/factories/stages.rb
+++ b/test/factories/stages.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stages
+#
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  project_id              :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  alert_emails            :text
+#  locked_by_deployment_id :integer
+#  locked                  :integer          default(0)
+#
+
 FactoryGirl.define do
   factory :stage do
     sequence(:name) { |n| "Stage %04d" % n }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  login                  :string(255)
+#  time_zone              :string(255)      default("UTC")
+#  disabled_at            :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0)
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default(FALSE)
+#
+
 FactoryGirl.define do
   factory :user do
     sequence(:login) { |n| "user_%04d" % n }

--- a/test/fixtures/configuration_parameters.yml
+++ b/test/fixtures/configuration_parameters.yml
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1

--- a/test/fixtures/deploy_keys.yml
+++ b/test/fixtures/deploy_keys.yml
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: deploy_keys
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  passphrase  :string(255)
+#  private_key :text
+#  public_key  :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:

--- a/test/fixtures/deployments.yml
+++ b/test/fixtures/deployments.yml
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: deployments
+#
+#  id                :integer          not null, primary key
+#  task              :string(255)
+#  log               :text
+#  stage_id          :integer
+#  created_at        :datetime
+#  updated_at        :datetime
+#  completed_at      :datetime
+#  description       :text
+#  user_id           :integer
+#  excluded_host_ids :string(255)
+#  revision          :string(255)
+#  pid               :integer
+#  status            :string(255)      default("running")
+#
+
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1

--- a/test/fixtures/hosts.yml
+++ b/test/fixtures/hosts.yml
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: hosts
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
+
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  template    :string(255)
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  body        :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  stage_id   :integer
+#  host_id    :integer
+#  primary    :integer          default(0)
+#  created_at :datetime
+#  updated_at :datetime
+#  no_release :integer          default(0)
+#  ssh_port   :integer
+#  no_symlink :integer          default(0)
+#
+
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 one:
   id: 1

--- a/test/fixtures/stages.yml
+++ b/test/fixtures/stages.yml
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: stages
+#
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  project_id              :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  alert_emails            :text
+#  locked_by_deployment_id :integer
+#  locked                  :integer          default(0)
+#
+

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  login                  :string(255)
+#  time_zone              :string(255)      default("UTC")
+#  disabled_at            :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0)
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default(FALSE)
+#
+

--- a/test/models/deploy_key_test.rb
+++ b/test/models/deploy_key_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: deploy_keys
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  passphrase  :string(255)
+#  private_key :text
+#  public_key  :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 require 'test_helper'
 
 class DeployKeyTest < ActiveSupport::TestCase

--- a/test/unit/configuration_parameter_test.rb
+++ b/test/unit/configuration_parameter_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 require 'test_helper'
 
 class ConfigurationParameterTest < ActiveSupport::TestCase

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: deployments
+#
+#  id                :integer          not null, primary key
+#  task              :string(255)
+#  log               :text
+#  stage_id          :integer
+#  created_at        :datetime
+#  updated_at        :datetime
+#  completed_at      :datetime
+#  description       :text
+#  user_id           :integer
+#  excluded_host_ids :string(255)
+#  revision          :string(255)
+#  pid               :integer
+#  status            :string(255)      default("running")
+#
+
 require 'test_helper'
 
 class DeploymentTest < ActiveSupport::TestCase

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: hosts
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
+
 require 'test_helper'
 
 class HostTest < ActiveSupport::TestCase

--- a/test/unit/project_configuration_test.rb
+++ b/test/unit/project_configuration_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 require 'test_helper'
 
 class ProjectConfigurationTest < ActiveSupport::TestCase

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  template    :string(255)
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 require 'test_helper'
 
 class ProjectTest < ActiveSupport::TestCase

--- a/test/unit/recipe_test.rb
+++ b/test/unit/recipe_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  description :text
+#  body        :text
+#  created_at  :datetime
+#  updated_at  :datetime
+#
+
 require 'test_helper'
 
 class RecipeTest < ActiveSupport::TestCase

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  stage_id   :integer
+#  host_id    :integer
+#  primary    :integer          default(0)
+#  created_at :datetime
+#  updated_at :datetime
+#  no_release :integer          default(0)
+#  ssh_port   :integer
+#  no_symlink :integer          default(0)
+#
+
 require 'test_helper'
 
 class RoleTest < ActiveSupport::TestCase

--- a/test/unit/stage_configuration_test.rb
+++ b/test/unit/stage_configuration_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: configuration_parameters
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)
+#  value            :string(255)
+#  project_id       :integer
+#  stage_id         :integer
+#  type             :string(255)
+#  created_at       :datetime
+#  updated_at       :datetime
+#  prompt_on_deploy :integer          default(0)
+#
+
 require 'test_helper'
 
 class StageConfigurationTest < ActiveSupport::TestCase

--- a/test/unit/stage_test.rb
+++ b/test/unit/stage_test.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stages
+#
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  project_id              :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  alert_emails            :text
+#  locked_by_deployment_id :integer
+#  locked                  :integer          default(0)
+#
+
 require 'test_helper'
 
 class StageTest < ActiveSupport::TestCase

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  login                  :string(255)
+#  time_zone              :string(255)      default("UTC")
+#  disabled_at            :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0)
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default(FALSE)
+#
+
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
migrateファイルがいっぱい出来るのが嫌だったので，ちょっと直接いじっています．
試すときは`rake db:migrate:reset db:seed`をした後に試してもらえればと思います．

基本的にはdeploy_keys#createでinsert_keysというモデルのインスタンスメソッドはやして
その中でSSHKeyを発行して保存しているだけです．

あとsecret_keyよりはprivate_keyかなと思ったのでカラム名を修正しました．
